### PR TITLE
indicators now have the same color as text

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -1,9 +1,9 @@
 # class                 border  bground text    indicator child_border
-client.focused          #6272A4 #6272A4 #F8F8F2 #6272A4   #6272A4
-client.focused_inactive #44475A #44475A #F8F8F2 #44475A   #44475A
-client.unfocused        #282A36 #282A36 #BFBFBF #282A36   #282A36
-client.urgent           #44475A #FF5555 #F8F8F2 #FF5555   #FF5555
-client.placeholder      #282A36 #282A36 #F8F8F2 #282A36   #282A36
+client.focused          #6272A4 #6272A4 #F8F8F2 #F8F8F2   #6272A4
+client.focused_inactive #44475A #44475A #F8F8F2 #F8F8F2   #44475A
+client.unfocused        #282A36 #282A36 #BFBFBF #BFBFBF   #282A36
+client.urgent           #44475A #FF5555 #F8F8F2 #F8F8F2   #FF5555
+client.placeholder      #282A36 #282A36 #F8F8F2 #F8F8F2   #282A36
 
 client.background       #F8F8F2
 


### PR DESCRIPTION
changed the colors for the indicator to match the color for text. The indicator was not distinguishable from the normal border before.
before:
![invisible_indicator](https://user-images.githubusercontent.com/48922273/94064962-b93a4600-fdea-11ea-9899-e8741d03414b.png)
after:
![visible_indicator](https://user-images.githubusercontent.com/48922273/94065096-f1da1f80-fdea-11ea-830f-2b8792c83160.png)
(the indicator is can be seen as the white line on the bottom of the second screenshot)